### PR TITLE
[imp] allow passing html into msg

### DIFF
--- a/cms_status_message/templates/status_message.xml
+++ b/cms_status_message/templates/status_message.xml
@@ -12,14 +12,24 @@
                       <span t-translation="off" aria-hidden="true" class="fa fa-remove"></span>
                     </button>
                 </t>
-                <t t-if="msg['title']">
-                    <strong class="title" t-esc="msg['title']" />
-                </t>
-                <span class="msg" t-esc="msg['msg']" />
+                <t t-call="cms_status_message.message_wrapper" />
               </div>
             </t>
           </div>
         </t>
+    </template>
+
+    <template id="message_wrapper" name="CMS status_message wrapper">
+        <div class="msg-wrapper row">
+            <t t-if="msg['title']">
+                <div class="title col-md-3">
+                    <strong t-esc="msg['title']" />
+                </div>
+            </t>
+            <div t-attf-class="msg #{msg['title'] and 'col-md-9' or 'col-md-12'}">
+                <t t-raw="msg['msg']" />
+            </div>
+        </div>
     </template>
 
     <template id="add_status_message" inherit_id="website.layout" name="Add status message">

--- a/cms_status_message/tests/test_message.py
+++ b/cms_status_message/tests/test_message.py
@@ -80,8 +80,10 @@ class HTMLCase(HttpCase):
             self.assertEqual(msg.attrib['role'], 'alert')
             self.assertEqual(msg.attrib['class'],
                              'alert alert-info alert-dismissible')
-            self.assertEqual(msg.find_class('msg')[0].text, 'oh yeah!')
-            self.assertEqual(msg.find_class('title')[0].text, 'Info')
+            self.assertEqual(
+                msg.find_class('msg')[0].text.strip(), 'oh yeah!')
+            self.assertEqual(
+                msg.find_class('title')[0].text_content().strip(), 'Info')
 
     def test_message_render_types(self):
         with self.mock_assets() as assets:
@@ -105,8 +107,10 @@ class HTMLCase(HttpCase):
                 self.assertEqual(el.attrib['role'], 'alert')
                 klass = 'alert alert-{} alert-dismissible'.format(type_)
                 self.assertEqual(el.attrib['class'], klass)
-                self.assertEqual(el.find_class('msg')[0].text, msg)
-                self.assertEqual(el.find_class('title')[0].text, title)
+                self.assertEqual(
+                    el.find_class('msg')[0].text.strip(), msg)
+                self.assertEqual(
+                    el.find_class('title')[0].text_content().strip(), title)
 
     def test_message_render_no_title(self):
         with self.mock_assets() as assets:
@@ -119,7 +123,7 @@ class HTMLCase(HttpCase):
             html_ = self.html_get_doc('/')
             msg = html_.find_class('alert')[0]
             self.assertEqual(
-                msg.find_class('msg')[0].text, 'no title pls!')
+                msg.find_class('msg')[0].text.strip(), 'no title pls!')
             self.assertFalse(msg.find_class('title'))
 
     def test_message_render_dismissible(self):


### PR DESCRIPTION
You can now pass bare html into message.
This allow to format the msg on multiple lines or to insert links.
Plus, message content has been splitted into a separate template.

NOTE: not sure if we need some sanitation here, since the msg content is not populated by the end user.