### PR TITLE
cms_form: fix search form regression on permission check

### DIFF
--- a/cms_form/models/cms_form_mixin.py
+++ b/cms_form/models/cms_form_mixin.py
@@ -143,6 +143,7 @@ class CMSFormMixin(models.AbstractModel):
             self._can_edit()
         else:
             self._can_create()
+        return True
 
     def _can_create(self, raise_exception=True):
         """Check that current user can create instances of given model."""

--- a/cms_form/models/cms_search_form.py
+++ b/cms_form/models/cms_search_form.py
@@ -25,6 +25,10 @@ class CMSFormSearch(models.AbstractModel):
     # declare fields that must be searched w/ multiple values
     _form_search_fields_multi = ()
 
+    def form_check_permission(self):
+        """Just searching, nothing to check here."""
+        return True
+
     def form_update_fields_attributes(self, _fields):
         """No field should be mandatory."""
         super().form_update_fields_attributes(_fields)

--- a/cms_form/tests/test_form_search.py
+++ b/cms_form/tests/test_form_search.py
@@ -61,9 +61,10 @@ class TestCMSSearchForm(FormTestCase):
             sorted(expected.mapped('id')),
         )
 
-    def get_search_form(self, data, form_model='cms.form.search.res.partner'):
+    def get_search_form(
+            self, data, form_model='cms.form.search.res.partner', **kw):
         request = fake_request(form_data=data)
-        form = self.get_form(form_model, req=request)
+        form = self.get_form(form_model, req=request, **kw)
         # restrict search results to these ids
         form.test_record_ids = self.expected_partners_ids
         return form
@@ -94,10 +95,15 @@ class TestCMSSearchForm(FormTestCase):
             self.env.ref('base.it').id,
             self.env.ref('base.fr').id,
         ]
-        data = {'country_id':  ','.join(map(str, countries))}
+        data = {'country_id': ','.join(map(str, countries))}
         form = self.get_search_form(
             data, form_model='cms.form.search.res.partner.multicountry')
         form.form_process()
         expected = self.expected_partners.filtered(
             lambda x: x.country_id.id in countries)
         self.assert_results(form, 3, expected)
+
+    def test_search_form_bypass_security_check(self):
+        form = self.get_search_form(
+            {}, sudo_uid=self.env.ref('base.public_user').id)
+        self.assertTrue(form.form_check_permission())


### PR DESCRIPTION
In 32a662e I've moved permission check from controller to form
but I missed the bypass for search forms.