### PR TITLE
cms_status_message: improve JS API

### DIFF
--- a/cms_status_message/README.rst
+++ b/cms_status_message/README.rst
@@ -76,14 +76,13 @@ Inject a custom message on the fly:
         'title': _t('Warning'),
         'type': 'warning'
     }
-    // wipe existing
-    $('.status_message').remove();
+    msg_tool.render_messages(msg).then(function(html) {
+        // wipe existing
+        $('.status_message').remove();
+        // inject new
+        $(html).hide().prependTo('#wrap').fadeIn('slow');
+    });
 
-    // inject new
-    $(msg_tool.render_messages(msg))
-        .hide()
-        .prependTo('main')
-        .fadeIn('slow');
 
 Add a status message to the session, useful if you want to show the
 message only after a redirect:

--- a/cms_status_message/static/src/js/tool.js
+++ b/cms_status_message/static/src/js/tool.js
@@ -5,21 +5,28 @@ odoo.define('cms_status_message.tool', function (require) {
         ajax = require('web.ajax');
     var qweb = core.qweb;
 
-    // load existing qweb templates
-    ajax.jsonRpc('/web/dataset/call', 'call', {
-        'model': 'ir.ui.view',
-        'method': 'read_template',
-        'args': ['cms_status_message.message_listing_wrapper']
-    }).done(function (data) {
-        qweb.add_template(data);
-    });
-    ajax.jsonRpc('/web/dataset/call', 'call', {
-        'model': 'ir.ui.view',
-        'method': 'read_template',
-        'args': ['cms_status_message.message_wrapper']
-    }).done(function (data) {
-        qweb.add_template(data);
-    });
+    var load_templates = function load_templates(names) {
+        // load existing qweb templates
+        var wait_for = [];
+        $.each(names, function(){
+            var def = $.Deferred();
+            if (this in qweb.templates) {
+                // already loaded
+                def.resolve();
+            } else {
+                ajax.jsonRpc('/web/dataset/call', 'call', {
+                    'model': 'ir.ui.view',
+                    'method': 'read_template',
+                    'args': [this]
+                }).done(function (data) {
+                    qweb.add_template(data);
+                    def.resolve()
+                });
+            }
+            wait_for.push(def);
+        });
+        return $.when.apply($, wait_for);
+    };
 
     var MessageTool = {
         add_message: function add_message (msg, options) {
@@ -37,24 +44,31 @@ odoo.define('cms_status_message.tool', function (require) {
             });
         },
         render_messages: function render_messages(msg, selector) {
-            // defaults
-            var status_message = {
-                'msg': '',
-                'title': null,
-                'type': 'info',
-                'dismissible': true
-            };
-            // inject user values
-            $.extend(status_message, msg);
-            // render it
-            var result = qweb.render(
+            var def = $.Deferred();
+            load_templates([
                 'cms_status_message.message_listing_wrapper',
-                {status_message: [status_message]}
-            );
-            if(selector){
-                $(result).prependTo(selector);
-            }
-            return result;
+                'cms_status_message.message_wrapper',
+            ]).done(function () {
+                // defaults
+                var status_message = {
+                    'msg': '',
+                    'title': null,
+                    'type': 'info',
+                    'dismissible': true
+                };
+                // inject user values
+                $.extend(status_message, msg);
+                // render it
+                var result = qweb.render(
+                    'cms_status_message.message_listing_wrapper',
+                    {status_message: [status_message]}
+                );
+                if(selector){
+                    $(result).prependTo(selector);
+                }
+                def.resolve(result);
+            });
+            return def;
         }
     };
 


### PR DESCRIPTION
1. load qweb template on demand
2. load qweb template only if not loaded yet
3. use promises for rendering

We load qweb templates via JS. Prior to this change we got 1 request every time ,
on every page load per each template, even if we were not using any status message feature.

Now we load templates only when needed and we load it only if not loaded yet,
lowering page load time a bit :)

Plus, rendering now returns a promise object so you can chain calls
and do things when rendering is really finished.