### PR TITLE
Toolbar: do not render for anon users

### DIFF
--- a/cms_toolbar/models/website_mixin.py
+++ b/cms_toolbar/models/website_mixin.py
@@ -10,6 +10,9 @@ class WebsiteMixin(models.AbstractModel):
 
     @api.model
     def cms_render_toolbar(self, **kw):
+        if self.env.user._is_public():
+            # no anon action
+            return ''
         values = self.cms_info()
         values.update({
             'show_create': values['can_create'],


### PR DESCRIPTION
Is pointless to render a toolbar if user is anon.
Also, this leads to ACL error log entries.