### PR TITLE
cms_form: fix regression fields ordering + hidden

### DIFF
--- a/cms_form/models/cms_form_mixin.py
+++ b/cms_form/models/cms_form_mixin.py
@@ -229,8 +229,12 @@ class CMSFormMixin(models.AbstractModel):
         # update fields attributes
         self.form_update_fields_attributes(_fields)
         if hidden is not None:
-            return {k: v for k, v in _fields.items()
-                    if v.get('hidden', False) == hidden}
+            # make sure ordering is preserved
+            filtered = OrderedDict()
+            for k, v in _fields.items():
+                if v.get('hidden', False) == hidden:
+                    filtered[k] = v
+            return filtered
         return _fields
 
     @tools.cache('self')

--- a/cms_form/tests/test_form_base.py
+++ b/cms_form/tests/test_form_base.py
@@ -115,6 +115,22 @@ class TestFormBase(FormTestCase):
         self.assertListEqual(sorted(fields.keys()), ['country_id', ])
         self.assertTrue(fields['country_id']['hidden'])
 
+    def test_fields_hidden_keep_order(self):
+        form = self.get_form(
+            'cms.form.res.partner',
+            fields_hidden=('country_id', ),
+            fields_order=['country_id', 'name', 'custom'])
+        fields = form.form_fields(hidden=False)
+        self.assertListEqual(
+            list(fields.keys()), ['name', 'custom'])
+        form = self.get_form(
+            'cms.form.res.partner',
+            fields_hidden=('country_id', ),
+            fields_order=['country_id', 'custom', 'name'])
+        fields = form.form_fields(hidden=False)
+        self.assertListEqual(
+            list(fields.keys()), ['custom', 'name', ])
+
     def test_get_loader(self):
         form = self.get_form('cms.form.test_fields')
         expected = {}.fromkeys((


### PR DESCRIPTION
When calling `form_fields` w/ hidden=True/False
the order of the fields was not respected anymore.

This a regression from commit 56b37ca