### PR TITLE
cms_form: fix ordering w/ `groups` protected fields

### DIFF
--- a/cms_form/models/cms_form_mixin.py
+++ b/cms_form/models/cms_form_mixin.py
@@ -287,7 +287,10 @@ class CMSFormMixin(models.AbstractModel):
         if self._form_fields_order:
             _sorted_all_fields = OrderedDict()
             for fname in self._form_fields_order:
-                _sorted_all_fields[fname] = _all_fields[fname]
+                # this check is required since you can have `groups` attribute
+                # on a field, making the field unavailable if not satisfied.
+                if fname in _all_fields:
+                    _sorted_all_fields[fname] = _all_fields[fname]
             _all_fields = _sorted_all_fields
         # compute subfields and remove them from all fields if any
         self._form_prepare_subfields(_all_fields)

--- a/cms_form/tests/fake_models.py
+++ b/cms_form/tests/fake_models.py
@@ -23,6 +23,18 @@ class FakePartnerForm(models.AbstractModel):
         return req_values.get('custom', 'oh yeah!')
 
 
+class FakePartnerFormProtectedFields(models.AbstractModel):
+    """A test model form w/ `groups` protected fields."""
+
+    _name = 'cms.form.protected.fields'
+    _inherit = 'cms.form'
+    # we'll test specifically that ordering won't break
+    _form_fields_order = ['ihaveagroup', 'nogroup']
+
+    nogroup = fields.Char()
+    ihaveagroup = fields.Char(groups='website.group_website_designer')
+
+
 class FakeSearchPartnerForm(models.AbstractModel):
     """A test model search form."""
 


### PR DESCRIPTION
If `groups` attribute was assigned to a field
it made fields ordering crash as the field is not there
when groups are not satisfied