### PR TITLE
Request values conversion fixes + more test coverage

### DIFF
--- a/cms_form/marshallers.py
+++ b/cms_form/marshallers.py
@@ -56,7 +56,7 @@ def marshal_dict(values, orig_key, orig_value):
         `$fname.$dict_key:dict`
 
     Every request key matching `$fname` prefix
-    will be merge into a dict wheres keys will match all `$dict_key`.
+    will be merged into a dict whereas keys will match all `$dict_key`.
 
     Example:
 
@@ -82,7 +82,7 @@ def marshal_dict(values, orig_key, orig_value):
         if not _k.startswith(key):
             continue
         # TODO: `__` will be to support extra marshallers, like:
-        # foo.1:record:int -> get a dictionary w/ integer values
+        # foo.1:dict:int -> get a dictionary w/ integer values
         full_key, _, __ = _k.partition(':dict')
         res[full_key.split('.')[-1]] = _v
     return key, res

--- a/cms_form/marshallers.py
+++ b/cms_form/marshallers.py
@@ -8,6 +8,7 @@ def marshal_request_values(values):
     Available marshallers:
 
     * `:int` transform to integer
+    * `:float` transform to float
     * `:list` transform to list of values
     * `:dict` transform to dictionary of values
     """
@@ -30,6 +31,10 @@ def marshal_request_values(values):
             k, v = marshal_int(values, k, v)
             res[k] = v
             continue
+        if k.endswith(':float'):
+            k, v = marshal_float(values, k, v)
+            res[k] = v
+            continue
         res[k] = v
     return res
 
@@ -45,6 +50,16 @@ def marshal_int(values, orig_key, orig_value):
     """Transform `foo:int` inputs to integer values."""
     k = orig_key[:-len(':int')]
     v = int(orig_value) if orig_value and orig_value.isdigit() else orig_value
+    return k, v
+
+
+def marshal_float(values, orig_key, orig_value):
+    """Transform `foo:float` inputs to float values."""
+    k = orig_key[:-len(':float')]
+    try:
+        v = float(orig_value.replace(',', '.'))
+    except (ValueError, TypeError):
+        v = orig_value
     return k, v
 
 

--- a/cms_form/models/cms_form_mixin.py
+++ b/cms_form/models/cms_form_mixin.py
@@ -552,11 +552,13 @@ class CMSFormMixin(models.AbstractModel):
         """
         klass = ''
         if self.form_display_mode == 'horizontal':
-            klass = 'form-horizontal '
+            klass = 'form-horizontal'
         elif self.form_display_mode == 'vertical':
             # actually not a real BS3 css klass but helps styling
-            klass = 'form-vertical '
-        return klass + self._form_extra_css_klass
+            klass = 'form-vertical'
+        if self._form_extra_css_klass:
+            klass += ' ' + self._form_extra_css_klass
+        return klass
 
     def form_make_field_wrapper_klass(self, fname, field, **kw):
         """Return specific CSS klass for the field wrapper."""

--- a/cms_form/models/cms_form_mixin.py
+++ b/cms_form/models/cms_form_mixin.py
@@ -316,7 +316,14 @@ class CMSFormMixin(models.AbstractModel):
             _all_fields.pop(fname, None)
 
     def form_fieldsets(self):
-        return self._form_fieldsets
+        # exclude empty ones
+        form_fields = self._form_fields()
+        res = []
+        for fset in self._form_fieldsets:
+            if any([form_fields.get(fname) for fname in fset['fields']]):
+                # at least one field is here
+                res.append(fset)
+        return res
 
     @property
     def form_fieldsets_wrapper_klass(self):

--- a/cms_form/models/widgets.py
+++ b/cms_form/models/widgets.py
@@ -22,6 +22,7 @@ class Widget(models.AbstractModel):
                     data=None, subfields=None, template='', css_klass=''):
         widget = self.new()
         widget.w_form = form
+        widget.w_form_model = form.form_model
         widget.w_record = form.main_object
         widget.w_form_values = form.form_render_values
         widget.w_fname = fname
@@ -59,9 +60,11 @@ class Widget(models.AbstractModel):
         """Extract value from form submit."""
         return req_values.get(self.w_fname)
 
-    def w_ids_from_input(self, value):
+    @staticmethod
+    def w_ids_from_input(value):
         """Convert list of ids from form input."""
-        return [int(rec_id) for rec_id in value.split(',') if rec_id.isdigit()]
+        return [int(rec_id.strip())
+                for rec_id in value.split(',') if rec_id.strip().isdigit()]
 
     def w_subfields_by_value(self, value='_all'):
         return self.w_subfields.get(value, {})
@@ -259,7 +262,7 @@ class X2MWidget(models.AbstractModel):
                 value == req_values.get(self.w_fname)):
             # value from request
             # FIXME: the field could come from the form not the model!
-            value = self.w_form.form_model[self.w_fname].browse(
+            value = self.w_form_model[self.w_fname].browse(
                 self.w_ids_from_input(value)).read(['name'])
         value = json.dumps(value)
         return value

--- a/cms_form/models/widgets.py
+++ b/cms_form/models/widgets.py
@@ -90,11 +90,15 @@ class HiddenWidget(models.AbstractModel):
         marshaller = ''
         if self.w_field['type'] in ('many2one', 'integer'):
             marshaller = ':int'
+        elif self.w_field['type'] in ('float', ):
+            marshaller = ':float'
         elif self.w_field['type'] == 'selection' and self.w_field['selection']:
             first_value = self.w_field['selection'][0][0]
             # fields.Selection does the same check to determine PG col type
             if isinstance(first_value, int):
                 marshaller = ':int'
+            elif isinstance(first_value, float):
+                marshaller = ':float'
         return self.w_fname + marshaller
 
 

--- a/cms_form/models/widgets.py
+++ b/cms_form/models/widgets.py
@@ -88,7 +88,7 @@ class HiddenWidget(models.AbstractModel):
     def w_html_fname(self):
         """Field name for final HTML markup."""
         marshaller = ''
-        if self.w_field['type'] == 'many2one':
+        if self.w_field['type'] in ('many2one', 'integer'):
             marshaller = ':int'
         elif self.w_field['type'] == 'selection' and self.w_field['selection']:
             first_value = self.w_field['selection'][0][0]

--- a/cms_form/models/widgets.py
+++ b/cms_form/models/widgets.py
@@ -81,6 +81,19 @@ class HiddenWidget(models.AbstractModel):
     _inherit = 'cms.form.widget.mixin'
     _w_template = 'cms_form.field_widget_hidden'
 
+    @property
+    def w_html_fname(self):
+        """Field name for final HTML markup."""
+        marshaller = ''
+        if self.w_field['type'] == 'many2one':
+            marshaller = ':int'
+        elif self.w_field['type'] == 'selection' and self.w_field['selection']:
+            first_value = self.w_field['selection'][0][0]
+            # fields.Selection does the same check to determine PG col type
+            if isinstance(first_value, int):
+                marshaller = ':int'
+        return self.w_fname + marshaller
+
 
 class IntegerWidget(models.AbstractModel):
     _name = 'cms.form.widget.integer'
@@ -169,7 +182,7 @@ class SelectionWidget(models.AbstractModel):
 
     def w_extract(self, **req_values):
         # Handle case where sel options are integers.
-        # TODO: unify this using marshallers?
+        # TODO: unify this using marshallers? See 'hidden' widget
         # Maybe we can have an internal field name
         # and a widget field name. In any case we should be careful
         # and not brake existing forms/widgets.

--- a/cms_form/models/widgets.py
+++ b/cms_form/models/widgets.py
@@ -157,7 +157,7 @@ class M2OWidget(models.AbstractModel):
         return self.form_to_m2o(value, **req_values)
 
     def form_to_m2o(self, value, **req_values):
-        val = utils.safe_to_integer(value)
+        val = utils.safe_to_integer(value) or 0
         # we don't want m2o value do be < 1
         return val > 0 and val or None
 

--- a/cms_form/templates/form.xml
+++ b/cms_form/templates/form.xml
@@ -95,7 +95,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 </template>
 
 <template id="single_field" name="CMS form single field">
-    <t t-if="not form_fields[fname].get('is_subfield')">
+    <t t-if="form_fields.get(fname) and not form_fields[fname].get('is_subfield')">
       <!-- this template is computed in `form_render`
       based on `form_display_mode`
       -->

--- a/cms_form/templates/widgets.xml
+++ b/cms_form/templates/widgets.xml
@@ -24,7 +24,7 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
   <input type="hidden"
          t-attf-class="#{widget.w_css_klass}"
-         t-att-name="widget.w_fname"
+         t-att-name="widget.w_html_fname"
          t-att-value="widget.w_field_value"
          t-att-required="widget.w_field['required'] and '1' or None"
          t-att-data-params='widget.w_data_json()'

--- a/cms_form/tests/__init__.py
+++ b/cms_form/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_form_search
 from . import test_form_wizard
 from . import test_loaders
 from . import test_marshallers
+from . import widgets

--- a/cms_form/tests/__init__.py
+++ b/cms_form/tests/__init__.py
@@ -7,4 +7,4 @@ from . import test_form_search
 from . import test_form_wizard
 from . import test_loaders
 from . import test_marshallers
-from . import widgets
+from .widgets import *

--- a/cms_form/tests/__init__.py
+++ b/cms_form/tests/__init__.py
@@ -7,4 +7,6 @@ from . import test_form_search
 from . import test_form_wizard
 from . import test_loaders
 from . import test_marshallers
-from .widgets import *
+from .widgets import test_widget_base
+from .widgets import test_widget_char
+from .widgets import test_widget_hidden

--- a/cms_form/tests/fake_models.py
+++ b/cms_form/tests/fake_models.py
@@ -107,6 +107,36 @@ class FakeFieldsForm(models.AbstractModel):
         return not len(value) > 8, 'Text length must be greater than 8!'
 
 
+class FakeFieldsFormWithFieldsets(models.AbstractModel):
+    """A test model form."""
+
+    _name = 'cms.form.test_fieldsets'
+    _inherit = 'cms.form.test_fields'
+    _form_fieldsets = [
+        {
+            'id': 'main',
+            'fields': ['a_char', ],
+        },
+        {
+            'id': 'numbers',
+            'title': 'Number fields',
+            'description': 'Only number fields here',
+            'fields': ['a_number', 'a_float'],
+            'css_extra_klass': 'best_fieldset',
+        },
+        {
+            'id': 'relations',
+            'title': 'Only relations here',
+            'fields': ['a_many2one', 'a_many2many', 'a_one2many'],
+        },
+        {
+            'id': 'protected',
+            'fields': ['ihaveagroup'],
+        },
+    ]
+    ihaveagroup = fields.Char(groups='website.group_website_designer')
+
+
 FAKE_STORAGE = {}
 
 

--- a/cms_form/tests/test_controllers.py
+++ b/cms_form/tests/test_controllers.py
@@ -1,9 +1,10 @@
 # Copyright 2017-2018 Simone Orsi
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
-
 from contextlib import contextmanager
 import mock
+import os
+import unittest
 
 from .common import FormHttpTestCase
 from ..controllers import main
@@ -14,6 +15,7 @@ from .utils import fake_request
 IMPORT = 'odoo.addons.cms_form.controllers.main'
 
 
+@unittest.skipIf(os.getenv('SKIP_HTTP_CASE'), 'HTTP case disabled.')
 class TestControllers(FormHttpTestCase):
 
     TEST_MODELS_KLASSES = [

--- a/cms_form/tests/test_form_base.py
+++ b/cms_form/tests/test_form_base.py
@@ -293,3 +293,23 @@ class TestFormBase(FormTestCase):
         })
         for k, v in values.items():
             self.assertEqual(expected[k], v)
+
+    def test_get_widget(self):
+        form = self.get_form('cms.form.test_fields')
+        expected = {
+            'a_char': 'cms.form.widget.char',
+            'a_number': 'cms.form.widget.integer',
+            'a_float': 'cms.form.widget.float',
+            'a_many2one': 'cms.form.widget.many2one',
+            'a_many2many': 'cms.form.widget.many2many',
+            'a_one2many': 'cms.form.widget.one2many',
+        }
+        fields = form.form_fields()
+        for fname, widget_model in expected.items():
+            self.assertEqual(
+                widget_model, form.form_get_widget_model(fname, fields[fname])
+            )
+            self.assertEqual(
+                form.form_get_widget(fname, fields[fname]).__class__,
+                self.env[widget_model].__class__
+            )

--- a/cms_form/tests/test_form_base.py
+++ b/cms_form/tests/test_form_base.py
@@ -313,3 +313,60 @@ class TestFormBase(FormTestCase):
                 form.form_get_widget(fname, fields[fname]).__class__,
                 self.env[widget_model].__class__
             )
+
+    def test_wrapper_css_klass(self):
+        form = self.get_form('cms.form.res.partner')
+        expected = (
+            'cms_form_wrapper cms_form_res_partner '
+            'res_partner mode_create'
+        )
+        self.assertEqual(
+            form.form_wrapper_css_klass,
+            expected
+        )
+        form._form_wrapper_extra_css_klass = 'foo'
+        expected = (
+            'cms_form_wrapper cms_form_res_partner '
+            'res_partner foo mode_create'
+        )
+        self.assertEqual(
+            form.form_wrapper_css_klass,
+            expected
+        )
+
+    def test_css_klass(self):
+        form = self.get_form('cms.form.res.partner')
+        self.assertEqual(form.form_css_klass, 'form-horizontal')
+        form._form_extra_css_klass = 'cool'
+        self.assertEqual(form.form_css_klass, 'form-horizontal cool')
+        form.form_display_mode = 'vertical'
+        self.assertEqual(form.form_css_klass, 'form-vertical cool')
+
+    def test_field_wrapper_css_klass(self):
+        form = self.get_form('cms.form.res.partner')
+        self.assertEqual(
+            form.form_make_field_wrapper_klass(
+                'foo_field',  {
+                    'type': 'char',
+                    'required': False,
+                }
+            ), 'form-group form-field field-char field-foo_field'
+        )
+        self.assertEqual(
+            form.form_make_field_wrapper_klass(
+                'foo_field_id',  {
+                    'type': 'many2one',
+                    'required': True,
+                }
+            ), ('form-group form-field field-many2one '
+                'field-foo_field_id field-required')
+        )
+        self.assertEqual(
+            form.form_make_field_wrapper_klass(
+                'foo_field',  {
+                    'type': 'float',
+                    'required': True,
+                }, errors={'foo_field': 'bad_value'}
+            ), ('form-group form-field field-float '
+                'field-foo_field field-required has-error')
+        )

--- a/cms_form/tests/test_form_base.py
+++ b/cms_form/tests/test_form_base.py
@@ -295,6 +295,25 @@ class TestFormBase(FormTestCase):
         for k, v in values.items():
             self.assertEqual(expected[k], v)
 
+    def test_extract_from_request_no_value(self):
+        """If you submit no value for a field it gets ignored."""
+        form = self.get_form('cms.form.test_fields')
+        # values from request
+        data = {
+            # not convertable value -> we'll get None
+            'a_float': '5/0',
+            'a_number': '10A',
+        }
+        request = fake_request(form_data=data)
+        form = self.get_form('cms.form.test_fields', req=request)
+        values = form.form_extract_values()
+        # these are converted to `None` and ignored
+        for fname in ['a_char', 'a_number', 'a_float', 'a_many2one', ]:
+            self.assertNotIn(fname, values)
+        # special case: when you don't submit a value form x2m we wipe it
+        for fname in ['a_many2many', 'a_one2many', ]:
+            self.assertEqual(values[fname], [(5, )])
+
     def test_get_widget(self):
         form = self.get_form('cms.form.test_fields')
         expected = {

--- a/cms_form/tests/test_form_base.py
+++ b/cms_form/tests/test_form_base.py
@@ -366,7 +366,7 @@ class TestFormBase(FormTestCase):
         form = self.get_form('cms.form.res.partner')
         self.assertEqual(
             form.form_make_field_wrapper_klass(
-                'foo_field',  {
+                'foo_field', {
                     'type': 'char',
                     'required': False,
                 }
@@ -374,7 +374,7 @@ class TestFormBase(FormTestCase):
         )
         self.assertEqual(
             form.form_make_field_wrapper_klass(
-                'foo_field_id',  {
+                'foo_field_id', {
                     'type': 'many2one',
                     'required': True,
                 }
@@ -383,7 +383,7 @@ class TestFormBase(FormTestCase):
         )
         self.assertEqual(
             form.form_make_field_wrapper_klass(
-                'foo_field',  {
+                'foo_field', {
                     'type': 'float',
                     'required': True,
                 }, errors={'foo_field': 'bad_value'}

--- a/cms_form/tests/test_form_base.py
+++ b/cms_form/tests/test_form_base.py
@@ -258,6 +258,7 @@ class TestFormBase(FormTestCase):
         for k, v in data.items():
             self.assertEqual(defaults[k], v)
 
+    # TODO: test marshallers integration
     def test_extract_from_request(self):
         form = self.get_form('cms.form.test_fields')
         # values from request

--- a/cms_form/tests/test_form_render.py
+++ b/cms_form/tests/test_form_render.py
@@ -2,12 +2,12 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from .common import FormRenderTestCase
-from .fake_models import FakeFieldsForm
+from .fake_models import FakeFieldsForm, FakeFieldsFormWithFieldsets
 
 
 class TestRender(FormRenderTestCase):
 
-    TEST_MODELS_KLASSES = [FakeFieldsForm, ]
+    TEST_MODELS_KLASSES = [FakeFieldsForm, FakeFieldsFormWithFieldsets]
 
     @classmethod
     def setUpClass(cls):
@@ -72,3 +72,66 @@ class TestRender(FormRenderTestCase):
                 fwrapper.attrib['class'],
                 form.form_make_field_wrapper_klass(fname, form_fields[fname])
             )
+
+    def test_render_form_fieldsets(self):
+        form = self.get_form('cms.form.test_fieldsets')
+        html = form.form_render()
+        node = self.to_xml_node(html)[0]
+        # we still get all the fields
+        expected_fields = (
+            'csrf_token',
+            'a_char',
+            'ihaveagroup',
+            'a_float',
+            'a_number',
+            'a_many2one',
+            'a_many2many',
+            'a_one2many',
+        )
+        # all fields are rendered
+        self.assertEqual(
+            len(node[0].xpath('//input|//select')), len(expected_fields)
+        )
+        self.assert_match_inputs(node, expected_fields)
+        # and they are organized by fieldset
+        for fset in form.form_fieldsets():
+            fset_node = node.xpath('//fieldset[@id="%s"]' % fset['id'])[0]
+            if fset.get('title'):
+                legend_node = fset_node.find('legend')
+                self.assertEqual(legend_node.text, fset['title'])
+            if fset.get('description'):
+                desc_node = \
+                    fset_node.find('p[@class="fieldset-description"]')
+                self.assertEqual(desc_node.text, fset['description'])
+            if fset.get('css_extra_klass'):
+                self.assertEqual(
+                    fset_node.attrib['class'], fset['css_extra_klass'])
+            # check all fields are contained into it
+            self.assert_match_inputs(fset_node, fset['fields'])
+
+    def test_render_form_fieldsets_protected_field(self):
+        """No field, no fieldset."""
+        user = self.env.ref('base.user_demo')
+        form = self.get_form('cms.form.test_fieldsets', sudo_uid=user.id)
+        html = form.form_render()
+        node = self.to_xml_node(html)[0]
+        # we still get all the fields
+        expected_fields = (
+            'csrf_token',
+            'a_char',
+            'a_float',
+            'a_number',
+            'a_many2one',
+            'a_many2many',
+            'a_one2many',
+        )
+        # all fields are rendered
+        self.assertEqual(
+            len(node[0].xpath('//input|//select')), len(expected_fields)
+        )
+        self.assert_match_inputs(node, expected_fields)
+        # protected field is not there
+        self.assertFalse(node[0].xpath('//input[@name="ihaveagroup"]'))
+        # also, since the field was the only one in the fieldset
+        # the fieldset as well should be gone
+        self.assertFalse(node[0].xpath('//fieldset[@id="protected"]'))

--- a/cms_form/tests/test_form_render.py
+++ b/cms_form/tests/test_form_render.py
@@ -44,11 +44,31 @@ class TestRender(FormRenderTestCase):
             'a_many2many',
             'a_one2many',
         )
+        # all fields are rendered
         self.assertEqual(
             len(node[0].xpath('//input|//select')), len(expected_fields)
         )
         self.assert_match_inputs(node, expected_fields)
 
-    def test_field_attrs(self):
-        # TODO: test all fields rendering
-        pass
+    def test_field_wrapper_attrs(self):
+        form = self.get_form('cms.form.test_fields')
+        form_fields = form.form_fields()
+        html = form.form_render()
+        node = self.to_xml_node(html)[0]
+        expected_fields = (
+            'a_char',
+            'a_float',
+            'a_number',
+            'a_many2one',
+            'a_many2many',
+            'a_one2many',
+        )
+        for fname in expected_fields:
+            fnode = self.find_input_name(node, fname)[0]
+            # catch 2nd one since the 1st is the main `form-fields` wrapper
+            fwrapper = fnode.xpath(
+                "ancestor::div[contains(@class, 'form-field')]")[1]
+            self.assertEqual(
+                fwrapper.attrib['class'],
+                form.form_make_field_wrapper_klass(fname, form_fields[fname])
+            )

--- a/cms_form/tests/test_marshallers.py
+++ b/cms_form/tests/test_marshallers.py
@@ -45,6 +45,21 @@ class TestMarshallers(unittest.TestCase):
         self.assertEqual(marshalled['c'], 3)
         self.assertEqual(marshalled['d'], 'bad')
 
+    def test_marshal_float(self):
+        data = MultiDict([
+            ('a', '1'),
+            ('b:float', '2'),
+            ('c:float', '3.0'),
+            ('d:float', '4,0'),
+            ('e:float', 'bad'),
+        ])
+        marshalled = marshallers.marshal_request_values(data)
+        self.assertEqual(marshalled['a'], '1')
+        self.assertEqual(marshalled['b'], 2.0)
+        self.assertEqual(marshalled['c'], 3.0)
+        self.assertEqual(marshalled['d'], 4.0)
+        self.assertEqual(marshalled['e'], 'bad')
+
     def test_marshal_dict(self):
         data = MultiDict([
             ('a', '1'),

--- a/cms_form/tests/test_marshallers.py
+++ b/cms_form/tests/test_marshallers.py
@@ -19,7 +19,7 @@ class TestMarshallers(unittest.TestCase):
         self.assertEqual(marshalled['b'], '2')
         self.assertEqual(marshalled['c'], '3')
 
-    def test_mashal_list(self):
+    def test_marshal_list(self):
         data = MultiDict([
             ('a', '1'),
             ('b:list', '1'),
@@ -32,7 +32,7 @@ class TestMarshallers(unittest.TestCase):
         self.assertListEqual(marshalled['b'], ['1', '2', '3'])
         self.assertEqual(marshalled['c'], '3')
 
-    def test_mashal_int(self):
+    def test_marshal_int(self):
         data = MultiDict([
             ('a', '1'),
             ('b:int', '2'),
@@ -45,7 +45,7 @@ class TestMarshallers(unittest.TestCase):
         self.assertEqual(marshalled['c'], 3)
         self.assertEqual(marshalled['d'], 'bad')
 
-    def test_mashal_dict(self):
+    def test_marshal_dict(self):
         data = MultiDict([
             ('a', '1'),
             ('b.x:dict', '1'),

--- a/cms_form/tests/test_widgets.py
+++ b/cms_form/tests/test_widgets.py
@@ -1,4 +1,0 @@
-# Copyright 2017-2018 Simone Orsi
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
-
-# TODO

--- a/cms_form/tests/widgets/__init__.py
+++ b/cms_form/tests/widgets/__init__.py
@@ -1,1 +1,2 @@
 from . import test_widget_base
+from . import test_widget_char

--- a/cms_form/tests/widgets/__init__.py
+++ b/cms_form/tests/widgets/__init__.py
@@ -1,0 +1,1 @@
+from . import test_widget_base

--- a/cms_form/tests/widgets/__init__.py
+++ b/cms_form/tests/widgets/__init__.py
@@ -1,2 +1,3 @@
 from . import test_widget_base
 from . import test_widget_char
+from . import test_widget_hidden

--- a/cms_form/tests/widgets/common.py
+++ b/cms_form/tests/widgets/common.py
@@ -1,0 +1,36 @@
+# Copyright 2018 Simone Orsi
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+
+from odoo.tests.common import SavepointCase
+import mock
+
+
+def fake_form():
+    return mock.MagicMock(name='FakeForm')
+
+
+def get_widget(env, fname, field, form=None, widget_model=None, **kw):
+    """Retrieve and initialize widget.
+    
+    :param form: an instance of a cms_form
+    :param fname: field name
+    :param field: field info matching `form_fields` schema
+    :param form: an instance of a cms_form
+    :param widget_model: if you don't pass a form you must pass a w model
+    """
+    if not form:
+        form = fake_form()
+    if not widget_model:
+        widget_model = form.form_get_widget_model(fname, field)
+    return env[widget_model].widget_init(
+        form, fname, field, **kw
+    )
+
+
+class TestWidgetCase(SavepointCase):
+
+    at_install = False
+    post_install = True
+
+    def get_widget(self, fname, field, **kw):
+        return get_widget(self.env, fname, field, **kw)

--- a/cms_form/tests/widgets/common.py
+++ b/cms_form/tests/widgets/common.py
@@ -5,6 +5,7 @@ import mock
 
 from ..common import HTMLRenderMixin
 
+
 def fake_form(**data):
     """Get a mocked fake form.
 
@@ -35,7 +36,7 @@ def fake_field(name, **kw):
 
 def get_widget(env, fname, field, form=None, widget_model=None, **kw):
     """Retrieve and initialize widget.
-    
+
     :param fname: field name
     :param field: field info matching `form_fields` schema
     :param form: an instance of a cms_form

--- a/cms_form/tests/widgets/common.py
+++ b/cms_form/tests/widgets/common.py
@@ -1,23 +1,47 @@
 # Copyright 2018 Simone Orsi
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
-
 from odoo.tests.common import SavepointCase
 import mock
 
+from ..common import HTMLRenderMixin
 
-def fake_form():
-    return mock.MagicMock(name='FakeForm')
+def fake_form(**data):
+    """Get a mocked fake form.
+
+    :param data: kw args for setting form values
+    """
+    form = mock.MagicMock(name='FakeForm')
+    form_values = mock.PropertyMock(return_value={'form_data': data})
+    type(form).form_render_values = form_values
+    return form
+
+
+def fake_field(name, **kw):
+    """Get fake field specs `form_fields` compliant.
+
+    :param name: field name
+    :param kw: kw args to override some values
+    """
+    info = {
+        'type': 'char',
+        'required': False,
+        'string': name.capitalize().replace('_', ' '),
+        'readonly': False,
+        'help': 'Help for %s' % name,
+    }
+    info.update(kw)
+    return name, info
 
 
 def get_widget(env, fname, field, form=None, widget_model=None, **kw):
     """Retrieve and initialize widget.
     
-    :param form: an instance of a cms_form
     :param fname: field name
     :param field: field info matching `form_fields` schema
     :param form: an instance of a cms_form
     :param widget_model: if you don't pass a form you must pass a w model
     """
+    assert form or widget_model
     if not form:
         form = fake_form()
     if not widget_model:
@@ -27,10 +51,11 @@ def get_widget(env, fname, field, form=None, widget_model=None, **kw):
     )
 
 
-class TestWidgetCase(SavepointCase):
+class TestWidgetCase(SavepointCase, HTMLRenderMixin):
 
     at_install = False
     post_install = True
 
-    def get_widget(self, fname, field, **kw):
-        return get_widget(self.env, fname, field, **kw)
+    @classmethod
+    def get_widget(cls, fname, field, **kw):
+        return get_widget(cls.env, fname, field, **kw)

--- a/cms_form/tests/widgets/test_widget_base.py
+++ b/cms_form/tests/widgets/test_widget_base.py
@@ -32,7 +32,7 @@ class TestWidgetBase(TestWidgetCase, FakeModelMixin):
         self.assertEqual(widget.w_field_value, None)
         self.assertEqual(widget.w_data, {})
         self.assertEqual(widget.w_subfields, {})
-    
+
     def test_w_load(self):
         name, field = fake_field('foo')
         widget = self.get_widget(

--- a/cms_form/tests/widgets/test_widget_base.py
+++ b/cms_form/tests/widgets/test_widget_base.py
@@ -1,0 +1,72 @@
+# Copyright 2018 Simone Orsi
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+from ..common import FakeModelMixin, get_form
+from ..fake_models import FakePartnerForm
+from .common import TestWidgetCase, fake_field
+
+
+class TestWidgetBase(TestWidgetCase, FakeModelMixin):
+
+    TEST_MODELS_KLASSES = [FakePartnerForm, ]
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls._setup_models()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls._teardown_models()
+        super().tearDownClass()
+
+    def test_widget_init(self):
+        form = get_form(self.env, 'cms.form.res.partner')
+        field = form.form_fields()['custom']
+        widget = self.get_widget('custom', field, form=form)
+        self.assertEqual(widget.w_form, form)
+        self.assertEqual(widget.w_form_model, form.form_model)
+        self.assertEqual(widget.w_record, form.main_object)
+        self.assertEqual(widget.w_form_values, form.form_render_values)
+        self.assertEqual(widget.w_fname, 'custom')
+        self.assertDictEqual(widget.w_field, field)
+        self.assertEqual(widget.w_field_value, None)
+        self.assertEqual(widget.w_data, {})
+        self.assertEqual(widget.w_subfields, {})
+    
+    def test_w_load(self):
+        name, field = fake_field('foo')
+        widget = self.get_widget(
+            name, field, widget_model='cms.form.widget.char')
+        # no value from default, nor from request, nor from record
+        self.assertEqual(widget.w_load(), None)
+        # get value from default. Default values from ORM
+        # are stored into internal key `_default` by `cms.form.mixin`
+        field['_default'] = 'oh yeah'
+        widget = self.get_widget(
+            name, field, widget_model='cms.form.widget.char')
+        self.assertEqual(widget.w_load(), 'oh yeah')
+        # get value from request and it has precedence over default
+        self.assertEqual(widget.w_load(foo='daje'), 'daje')
+        # get value from record (faked here)
+        widget.w_record = {'foo': 'value coming from record'}
+        self.assertEqual(widget.w_load(), 'value coming from record')
+        # still, value from request takes precedence
+        self.assertEqual(
+            widget.w_load(foo='I am more important'), 'I am more important')
+
+    def test_w_extract(self):
+        name, field = fake_field('foo')
+        widget = self.get_widget(
+            name, field, widget_model='cms.form.widget.char')
+        # no val in request
+        self.assertEqual(widget.w_extract(), None)
+        self.assertEqual(widget.w_extract(foo='yo!'), 'yo!')
+
+    def test_w_ids_from_input(self):
+        name, field = fake_field('foo')
+        widget = self.get_widget(
+            name, field, widget_model='cms.form.widget.char')
+        self.assertEqual(widget.w_ids_from_input(''), [])
+        # not valid values are skipped
+        self.assertEqual(widget.w_ids_from_input(
+            '1,2,3,#4, 70, 1XX, 200'), [1, 2, 3, 70, 200])

--- a/cms_form/tests/widgets/test_widget_char.py
+++ b/cms_form/tests/widgets/test_widget_char.py
@@ -29,7 +29,6 @@ class TestWidgetChar(TestWidgetCase):
             self.assertEqual(node_input[0].attrib[attr_name], attr_value)
         self.assertNotIn('required', node_input[0].attrib)
 
-
     def test_widget_char_input_required(self):
         self.widget.w_field['required'] = True
         node = self.to_xml_node(self.widget.render())[0]

--- a/cms_form/tests/widgets/test_widget_char.py
+++ b/cms_form/tests/widgets/test_widget_char.py
@@ -1,0 +1,47 @@
+# Copyright 2018 Simone Orsi
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+from .common import TestWidgetCase, fake_form, fake_field
+
+
+class TestWidgetChar(TestWidgetCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        form = fake_form(a_char_field='abc')
+        cls.w_name, cls.w_field = fake_field('a_char_field')
+        cls.widget = cls.get_widget(
+            cls.w_name, cls.w_field,
+            form=form, widget_model='cms.form.widget.char')
+
+    def test_widget_char_input(self):
+        node = self.to_xml_node(self.widget.render())[0]
+        node_input = self.find_input_name(node, self.w_name)
+        self.assertEqual(len(node_input), 1)
+        expected_attrs = {
+            'type': 'text',
+            'name': 'a_char_field',
+            'placeholder': 'A char field...',
+            'value': 'abc',
+            'class': 'form-control ',
+        }
+        for attr_name, attr_value in expected_attrs.items():
+            self.assertEqual(node_input[0].attrib[attr_name], attr_value)
+        self.assertNotIn('required', node_input[0].attrib)
+
+
+    def test_widget_char_input_required(self):
+        self.widget.w_field['required'] = True
+        node = self.to_xml_node(self.widget.render())[0]
+        node_input = self.find_input_name(node, self.w_name)
+        self.assertEqual(len(node_input), 1)
+        expected_attrs = {
+            'type': 'text',
+            'name': 'a_char_field',
+            'placeholder': 'A char field...',
+            'value': 'abc',
+            'class': 'form-control ',
+            'required': '1',
+        }
+        for attr_name, attr_value in expected_attrs.items():
+            self.assertEqual(node_input[0].attrib[attr_name], attr_value)

--- a/cms_form/tests/widgets/test_widget_hidden.py
+++ b/cms_form/tests/widgets/test_widget_hidden.py
@@ -1,0 +1,128 @@
+# Copyright 2018 Simone Orsi
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+from .common import TestWidgetCase, fake_form, fake_field
+
+
+class TestWidgetChar(TestWidgetCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.form = fake_form(
+            char_field='abc',
+            int_field=5,
+            float_field=5.0,
+            selection_str_field='1',
+            selection_integer_field=2,
+            many2one_field=10,
+        )
+
+    def test_widget_char_input_hidden(self):
+        """Test char field hidden."""
+        w_name, w_field = fake_field('char_field')
+        widget = self.get_widget(w_name, w_field, form=self.form,
+                                 widget_model='cms.form.widget.hidden')
+        node = self.to_xml_node(widget.render())[0]
+        node_input = self.find_input_name(node, widget.w_html_fname)
+        self.assertEqual(len(node_input), 1)
+        expected_attrs = {
+            'type': 'hidden',
+            'name': 'char_field',
+            'value': 'abc',
+        }
+        for attr_name, attr_value in expected_attrs.items():
+            self.assertEqual(node_input[0].attrib[attr_name], attr_value)
+        self.assertNotIn('required', node_input[0].attrib)
+        # make it required
+        # we'll test this only here: behavior is the same for each field type
+        widget.w_field['required'] = True
+        node = self.to_xml_node(widget.render())[0]
+        node_input = self.find_input_name(node, widget.w_html_fname)
+        self.assertIn('required', node_input[0].attrib)
+
+    def test_widget_integer_input_hidden(self):
+        """Test int field hidden."""
+        w_name, w_field = fake_field('int_field', type='integer')
+        widget = self.get_widget(w_name, w_field, form=self.form,
+                                 widget_model='cms.form.widget.hidden')
+        node = self.to_xml_node(widget.render())[0]
+        node_input = self.find_input_name(node, widget.w_html_fname)
+        self.assertEqual(len(node_input), 1)
+        expected_attrs = {
+            'type': 'hidden',
+            'name': 'int_field:int',
+            'value': '5',
+        }
+        for attr_name, attr_value in expected_attrs.items():
+            self.assertEqual(node_input[0].attrib[attr_name], attr_value)
+
+    # TODO: support float conversion
+    # def test_widget_float_input_hidden(self):
+    #     """Test float field hidden."""
+    #     w_name, w_field = fake_field('float_field', type='float')
+    #     widget = self.get_widget(w_name, w_field, form=self.form,
+    #                              widget_model='cms.form.widget.hidden')
+    #     node = self.to_xml_node(widget.render())[0]
+    #     node_input = self.find_input_name(node, widget.w_html_fname)
+    #     self.assertEqual(len(node_input), 1)
+    #     expected_attrs = {
+    #         'type': 'hidden',
+    #         'name': 'float_field:float',
+    #         'value': '5.0',
+    #     }
+    #     for attr_name, attr_value in expected_attrs.items():
+    #         self.assertEqual(node_input[0].attrib[attr_name], attr_value)
+
+    def test_widget_selection_string_input_hidden(self):
+        """Test selection field hidden."""
+        w_name, w_field = fake_field(
+            'selection_str_field',
+            type='selection',
+            selection=[('1', 'A'), ('2', 'B')])
+        widget = self.get_widget(w_name, w_field, form=self.form,
+                                 widget_model='cms.form.widget.hidden')
+        node = self.to_xml_node(widget.render())[0]
+        node_input = self.find_input_name(node, widget.w_html_fname)
+        self.assertEqual(len(node_input), 1)
+        expected_attrs = {
+            'type': 'hidden',
+            'name': 'selection_str_field',
+            'value': '1',
+        }
+        for attr_name, attr_value in expected_attrs.items():
+            self.assertEqual(node_input[0].attrib[attr_name], attr_value)
+
+    def test_widget_selection_integer_input_hidden(self):
+        """Test selection field hidden."""
+        w_name, w_field = fake_field(
+            'selection_integer_field',
+            type='selection',
+            selection=[(1, 'A'), (2, 'B')])
+        widget = self.get_widget(w_name, w_field, form=self.form,
+                                 widget_model='cms.form.widget.hidden')
+        node = self.to_xml_node(widget.render())[0]
+        node_input = self.find_input_name(node, widget.w_html_fname)
+        self.assertEqual(len(node_input), 1)
+        expected_attrs = {
+            'type': 'hidden',
+            'name': 'selection_integer_field:int',
+            'value': '2',
+        }
+        for attr_name, attr_value in expected_attrs.items():
+            self.assertEqual(node_input[0].attrib[attr_name], attr_value)
+
+    def test_widget_many2one_input_hidden(self):
+        """Test many2one field hidden."""
+        w_name, w_field = fake_field('many2one_field', type='many2one')
+        widget = self.get_widget(w_name, w_field, form=self.form,
+                                 widget_model='cms.form.widget.hidden')
+        node = self.to_xml_node(widget.render())[0]
+        node_input = self.find_input_name(node, widget.w_html_fname)
+        self.assertEqual(len(node_input), 1)
+        expected_attrs = {
+            'type': 'hidden',
+            'name': 'many2one_field:int',
+            'value': '10',
+        }
+        for attr_name, attr_value in expected_attrs.items():
+            self.assertEqual(node_input[0].attrib[attr_name], attr_value)

--- a/cms_form/tests/widgets/test_widget_hidden.py
+++ b/cms_form/tests/widgets/test_widget_hidden.py
@@ -9,11 +9,13 @@ class TestWidgetChar(TestWidgetCase):
     def setUpClass(cls):
         super().setUpClass()
         cls.form = fake_form(
+            # fake defaults
             char_field='abc',
             int_field=5,
             float_field=5.0,
             selection_str_field='1',
             selection_integer_field=2,
+            selection_float_field=4.0,
             many2one_field=10,
         )
 
@@ -56,25 +58,24 @@ class TestWidgetChar(TestWidgetCase):
         for attr_name, attr_value in expected_attrs.items():
             self.assertEqual(node_input[0].attrib[attr_name], attr_value)
 
-    # TODO: support float conversion
-    # def test_widget_float_input_hidden(self):
-    #     """Test float field hidden."""
-    #     w_name, w_field = fake_field('float_field', type='float')
-    #     widget = self.get_widget(w_name, w_field, form=self.form,
-    #                              widget_model='cms.form.widget.hidden')
-    #     node = self.to_xml_node(widget.render())[0]
-    #     node_input = self.find_input_name(node, widget.w_html_fname)
-    #     self.assertEqual(len(node_input), 1)
-    #     expected_attrs = {
-    #         'type': 'hidden',
-    #         'name': 'float_field:float',
-    #         'value': '5.0',
-    #     }
-    #     for attr_name, attr_value in expected_attrs.items():
-    #         self.assertEqual(node_input[0].attrib[attr_name], attr_value)
+    def test_widget_float_input_hidden(self):
+        """Test float field hidden."""
+        w_name, w_field = fake_field('float_field', type='float')
+        widget = self.get_widget(w_name, w_field, form=self.form,
+                                 widget_model='cms.form.widget.hidden')
+        node = self.to_xml_node(widget.render())[0]
+        node_input = self.find_input_name(node, widget.w_html_fname)
+        self.assertEqual(len(node_input), 1)
+        expected_attrs = {
+            'type': 'hidden',
+            'name': 'float_field:float',
+            'value': '5.0',
+        }
+        for attr_name, attr_value in expected_attrs.items():
+            self.assertEqual(node_input[0].attrib[attr_name], attr_value)
 
     def test_widget_selection_string_input_hidden(self):
-        """Test selection field hidden."""
+        """Test selection field hidden with string values."""
         w_name, w_field = fake_field(
             'selection_str_field',
             type='selection',
@@ -93,7 +94,7 @@ class TestWidgetChar(TestWidgetCase):
             self.assertEqual(node_input[0].attrib[attr_name], attr_value)
 
     def test_widget_selection_integer_input_hidden(self):
-        """Test selection field hidden."""
+        """Test selection field hidden with integer values."""
         w_name, w_field = fake_field(
             'selection_integer_field',
             type='selection',
@@ -107,6 +108,25 @@ class TestWidgetChar(TestWidgetCase):
             'type': 'hidden',
             'name': 'selection_integer_field:int',
             'value': '2',
+        }
+        for attr_name, attr_value in expected_attrs.items():
+            self.assertEqual(node_input[0].attrib[attr_name], attr_value)
+
+    def test_widget_selection_float_input_hidden(self):
+        """Test selection field hidden with float values."""
+        w_name, w_field = fake_field(
+            'selection_float_field',
+            type='selection',
+            selection=[(4.0, 'A'), (8.0, 'B')])
+        widget = self.get_widget(w_name, w_field, form=self.form,
+                                 widget_model='cms.form.widget.hidden')
+        node = self.to_xml_node(widget.render())[0]
+        node_input = self.find_input_name(node, widget.w_html_fname)
+        self.assertEqual(len(node_input), 1)
+        expected_attrs = {
+            'type': 'hidden',
+            'name': 'selection_float_field:float',
+            'value': '4.0',
         }
         for attr_name, attr_value in expected_attrs.items():
             self.assertEqual(node_input[0].attrib[attr_name], attr_value)

--- a/cms_form/utils.py
+++ b/cms_form/utils.py
@@ -7,14 +7,14 @@ def safe_to_integer(value, **kw):
     try:
         return int(value)
     except (ValueError, TypeError):
-        return 0
+        return None
 
 
 def safe_to_float(value, **kw):
     try:
         return float(value)
     except (ValueError, TypeError):
-        return 0.0
+        return None
 
 
 def safe_to_date(value, **kw):

--- a/cms_form/utils.py
+++ b/cms_form/utils.py
@@ -19,8 +19,10 @@ def safe_to_float(value, **kw):
 
 def safe_to_date(value, **kw):
     if not value:
-        # make sure we do not return empty string which breaks the ORM
-        return False
+        # 1. make sure we do not return empty string which breaks the ORM
+        # 2. return `None` so that request extractor ignores the field
+        # if it's not required
+        return None
     return value
 
 


### PR DESCRIPTION
* cms_form: hidden input respect field type value
    
    Hidden input values pass through requests as chars.
    This means that any m2o or selection field with integer values
    won't be really happy.
    
    Here we rely on request marshallers to convert those values
    to correct values based on field type.
    
    NOTE: this is the preliminary step for adopting marshallers
    for all field types/widgets when needed.

* cms_form: fix `safe_to_date` to make form extractor happy
    
    Form extractor ignores non required fields if their values is `None`.
    In the case of the date field, the util was returning `False`
    even if the value was not submitted, leading to an ORM error
    whenever the missing field was required.
    
    Now we return `None` and let the extractor deal with proper values
    and validation.


*   cms_form: add :float marshaller
    
    You can now use `$foo:float` as field name to cast value to float

*   cms_form: input hidden support cast to float
    
    Now when you use an hidden input on a float field,
    or a selection field w/ float values, you get request value converted to float

* cms_form: improve test coverage on rendering

* cms_form: test fieldsets rendering
    
  Make sure fieldsets are not rendered if they have no fields.
