### PR TITLE
[11.0][REF] cms_form: refactor date widget

### DIFF
--- a/cms_form/models/widgets/widget_date.py
+++ b/cms_form/models/widgets/widget_date.py
@@ -2,7 +2,6 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 from odoo import models
-
 from ... import utils
 
 
@@ -12,15 +11,20 @@ class DateWidget(models.AbstractModel):
     _inherit = 'cms.form.widget.mixin'
     _w_template = 'cms_form.field_widget_date'
 
-    # TODO: allow customization of date format
-    # TODO: adopt this attr to control placeholders on all widgets
-    w_placeholder = 'YYYY-MM-DD'
+    # Both default to current lang format.
+    w_placeholder = ''
+    w_date_format = ''
 
     def widget_init(self, form, fname, field, **kw):
         widget = super().widget_init(form, fname, field, **kw)
         if 'defaultToday' not in widget.w_data:
             # set today's date by default
             widget.w_data['defaultToday'] = True
+        if kw.get('format', widget.w_date_format):
+            widget.w_data['dp'] = {
+                'format': kw.get('format', widget.w_date_format)
+            }
+        widget.w_placeholder = kw.get('placeholder', widget.w_placeholder)
         return widget
 
     def w_extract(self, **req_values):
@@ -28,5 +32,4 @@ class DateWidget(models.AbstractModel):
         return self.form_to_date(value, **req_values)
 
     def form_to_date(self, value, **req_values):
-        # TODO: should be validated by current format
         return utils.safe_to_date(value)

--- a/cms_form/models/widgets/widget_date.py
+++ b/cms_form/models/widgets/widget_date.py
@@ -13,6 +13,8 @@ class DateWidget(models.AbstractModel):
     _w_template = 'cms_form.field_widget_date'
 
     # TODO: allow customization of date format
+    # TODO: adopt this attr to control placeholders on all widgets
+    w_placeholder = 'YYYY-MM-DD'
 
     def widget_init(self, form, fname, field, **kw):
         widget = super().widget_init(form, fname, field, **kw)

--- a/cms_form/models/widgets/widget_mixin.py
+++ b/cms_form/models/widgets/widget_mixin.py
@@ -13,7 +13,8 @@ class Widget(models.AbstractModel):
     _w_css_klass = ''
 
     def widget_init(self, form, fname, field,
-                    data=None, subfields=None, template='', css_klass=''):
+                    data=None, subfields=None,
+                    template='', css_klass='', **kw):
         widget = self.new()
         widget.w_form = form
         widget.w_form_model = form.form_model
@@ -64,4 +65,4 @@ class Widget(models.AbstractModel):
         return self.w_subfields.get(value, {})
 
     def w_data_json(self):
-        return json.dumps(self.w_data)
+        return json.dumps(self.w_data, sort_keys=True)

--- a/cms_form/static/src/js/date_widget.js
+++ b/cms_form/static/src/js/date_widget.js
@@ -1,14 +1,17 @@
 odoo.define('cms_form.date_widget', function (require) {
   'use strict';
 
-  require('web.dom_ready');
+  var sAnimation = require('website.content.snippets.animation');
 
-  // TODO: migrate to snippet animation
-  $(document).ready(function () {
-    $("input.js_datepicker").each(function () {
-      var $input = $(this);
-      var options = _.defaults(
-        $input.data('params') || {}, {
+  sAnimation.registry.CMSDateWidget = sAnimation.Class.extend({
+    selector: ".cms_form_wrapper form input.js_datepicker",
+    start: function () {
+      this.load_options();
+      this.setup_datepicker();
+    },
+    load_options: function() {
+      this.options = _.defaults(
+        this.$el.data('params') || {}, {
           useSeconds: false,
           icons: {
             time: 'fa fa-clock-o',
@@ -16,29 +19,38 @@ odoo.define('cms_form.date_widget', function (require) {
             up: 'fa fa-chevron-up',
             down: 'fa fa-chevron-down'
           },
-          dateFormat: $input.data('format')
+          // python = YYYY-MM-DD
+          dateFormat: 'yy-mm-dd'
         }
       )
-      $input.datepicker(options);
-      var defaultDate = $input.data('params').defaultDate;
+    },
+    setup_datepicker: function() {
+      var self = this;
+      this.$el.datepicker(this.options);
+      this.set_default_date();
+      this.$el
+        .closest('.input-group')
+        .find('.js_datepicker_trigger')
+        .click(function () {
+          self.$el.datepicker('show');
+        });
+    },
+    set_default_date: function () {
+      var self = this;
+      var defaultDate = self.options.defaultDate;
       if (defaultDate) {
         // use custom date
         defaultDate = new Date(defaultDate);
-      } else if ($input.data('params').defaultToday) {
+      } else if (self.options.defaultToday) {
         // unless blocked go for today date
         defaultDate = new Date();
       }
-      if (defaultDate && !$input.val()) {
-        $input.datepicker(
+      if (defaultDate && !self.$el.val()) {
+        self.$el.datepicker(
           "setDate", defaultDate
         );
       }
-      $input
-        .closest('.input-group')
-        .find('.js_datepicker_trigger').click(function () {
-          $input.datepicker('show');
-        });
-    });
+    }
 
   });
 

--- a/cms_form/static/src/js/date_widget.js
+++ b/cms_form/static/src/js/date_widget.js
@@ -2,56 +2,96 @@ odoo.define('cms_form.date_widget', function (require) {
   'use strict';
 
   var sAnimation = require('website.content.snippets.animation');
+  var time_utils = require('web.time');
 
   sAnimation.registry.CMSDateWidget = sAnimation.Class.extend({
     selector: ".cms_form_wrapper form input.js_datepicker",
     start: function () {
+      // The datepicker is attached to $fname_display field.
+      // The real value is held by the real field input (hidden).
+      this.$realField = this.$el.next(
+        '#' + this.$el.attr('name').replace('_display', '')
+      );
       this.load_options();
       this.setup_datepicker();
     },
     load_options: function() {
-      this.options = _.defaults(
-        this.$el.data('params') || {}, {
-          useSeconds: false,
+      // global options
+      this.options = _.omit(this.$el.data('params'), 'dp');
+      // datepicker specific ones
+      this.picker_options = _.defaults(
+        // You can pass datepicker specific options via `dp` attr in params.
+        // We don't pass them via `params` otherwise the picker
+        // will fail on it if non recognized params are there.
+        this.$el.data('params').dp || {},
+        {
           icons: {
             time: 'fa fa-clock-o',
             date: 'fa fa-calendar',
             up: 'fa fa-chevron-up',
             down: 'fa fa-chevron-down'
           },
-          // python = YYYY-MM-DD
-          dateFormat: 'yy-mm-dd'
+          locale: moment.locale(),
+          format: time_utils.getLangDateFormat(),
+          useCurrent: false
         }
       )
     },
     setup_datepicker: function() {
       var self = this;
-      this.$el.datepicker(this.options);
-      this.set_default_date();
+      var placeholder = this.$el.attr('placeholder');
+      // placeholder empty: set default via lang format
+      // plahoholder not defined: leave it not set
+      if (!placeholder && !_.isUndefined(placeholder)) {
+        /* TODO: we should make this translatable. Example:
+
+        lang format in French is `DD.MM.YYYY`
+        what the user wants to see is `JJ.MM.AAAA`
+
+        As workaround you can define the placeholder as widget attribute
+        and translate it.
+        */
+        this.$el.attr('placeholder', time_utils.getLangDateFormat());
+      }
+      // init bootstrap-datetimepicker
+      this.$el.datetimepicker(this.picker_options);
+      this.picker = this.$el.data('DateTimePicker');
+      this.$el.on('dp.change', function(e){
+        // Update real value field.
+        // WARNING: this format should not be touched, it matches server side.
+        var real_val = '';
+        // e.date is false when no value is set
+        if (e.date) {
+          real_val = e.date.format('YYYY-MM-DD');
+        }
+        self.$realField.val(real_val);
+      });
+      this._init_date();
+      // enable calendar icon trigger
       this.$el
         .closest('.input-group')
         .find('.js_datepicker_trigger')
         .click(function () {
-          self.$el.datepicker('show');
+          self.picker.show();
         });
     },
-    set_default_date: function () {
+    _init_date: function () {
       var self = this;
-      var defaultDate = self.options.defaultDate;
+      // retrieve current date from real field
+      var defaultDate = self.$realField.val();
       if (defaultDate) {
-        // use custom date
         defaultDate = new Date(defaultDate);
       } else if (self.options.defaultToday) {
-        // unless blocked go for today date
         defaultDate = new Date();
       }
       if (defaultDate && !self.$el.val()) {
-        self.$el.datepicker(
-          "setDate", defaultDate
-        );
+        this.picker.date(defaultDate)
       }
+    },
+    destroy: function() {
+      this.picker.destroy();
+      this._super.apply(this, arguments);
     }
-
   });
 
 });

--- a/cms_form/templates/widgets.xml
+++ b/cms_form/templates/widgets.xml
@@ -123,16 +123,20 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 
 
 <template id="field_widget_date" name="CMS form date field widget">
-
   <div class="input-group">
-    <!-- TODO: show date in user locale and convert value server side -->
-    <input t-att-name="widget.w_fname" t-att-id="widget.w_fname"
+    <!-- This will hold the value displayed to users -->
+    <input type="text"
+           t-attf-name="#{widget.w_fname}_display"
+           t-attf-id="#{widget.w_fname}_display"
            t-attf-class="form-control js_datepicker #{widget.w_css_klass}"
-           type="text"
            t-att-placeholder="widget.w_placeholder"
            t-att-data-params='widget.w_data_json()'
-           t-att-value="widget.w_field_value"
            t-att-required="widget.w_field['required'] and '1' or None"
+           />
+    <!-- This will hold server-side value -->
+    <input type="hidden" t-att-name="widget.w_fname"
+           t-att-id="widget.w_fname"
+           t-att-value="widget.w_field_value"
            />
     <span class="input-group-addon js_datepicker_trigger">
       <span class="fa fa-calendar"></span>

--- a/cms_form/templates/widgets.xml
+++ b/cms_form/templates/widgets.xml
@@ -128,7 +128,8 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
     <!-- TODO: show date in user locale and convert value server side -->
     <input t-att-name="widget.w_fname" t-att-id="widget.w_fname"
            t-attf-class="form-control js_datepicker #{widget.w_css_klass}"
-           type="text" data-format="yy-mm-dd" placeholder="YYYY-MM-DD"
+           type="text"
+           t-att-placeholder="widget.w_placeholder"
            t-att-data-params='widget.w_data_json()'
            t-att-value="widget.w_field_value"
            t-att-required="widget.w_field['required'] and '1' or None"

--- a/cms_form/tests/widgets/test_widget_date.py
+++ b/cms_form/tests/widgets/test_widget_date.py
@@ -1,5 +1,6 @@
 # Copyright 2019 Simone Orsi
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
+import json
 from .common import TestWidgetCase, fake_form, fake_field
 
 
@@ -8,57 +9,92 @@ class TestWidgetDate(TestWidgetCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        form = fake_form(a_date_field='2019-01-12', type='date')
+        cls.form = fake_form(a_date_field='2019-01-12', type='date')
         cls.w_name, cls.w_field = fake_field('a_date_field')
         cls.widget = cls.get_widget(
             cls.w_name, cls.w_field,
-            form=form, widget_model='cms.form.widget.date')
+            form=cls.form, widget_model='cms.form.widget.date')
 
     def test_widget_date_input(self):
+        node = self.to_xml_node(self.widget.render())[0]
+        # we have 2 inputs, display one
+        node_input_disp = self.find_input_name(node, self.w_name + '_display')
+        self.assertEqual(len(node_input_disp), 1)
         expected_attrs = {
             'type': 'text',
+            'id': 'a_date_field_display',
+            'name': 'a_date_field_display',
+            'class': 'form-control js_datepicker ',
+            'placeholder': '',
+        }
+        self._test_element_attributes(
+            node_input_disp[0], 'input', expected_attrs)
+
+        # TODO: check on json params on other widgets too
+        self.assertEqual(
+            json.loads(node_input_disp[0].attrib['data-params']), {
+                'defaultToday': True,
+            }
+        )
+        # and the real one holding the value which is hidden
+        node_input = self.find_input_name(node, self.w_name)
+        self.assertEqual(len(node_input), 1)
+        expected_attrs = {
+            'type': 'hidden',
             'id': 'a_date_field',
             'name': 'a_date_field',
-            'placeholder': 'YYYY-MM-DD',
             'value': '2019-01-12',
-            'data-format': 'yy-mm-dd',
-            'class': 'form-control js_datepicker ',
         }
-        self._test_widget_attributes(self.widget, 'input', expected_attrs)
+        self._test_element_attributes(node_input[0], 'input', expected_attrs)
 
     def test_widget_date_input_required(self):
         self.widget.w_field['required'] = True
         expected_attrs = {
             'type': 'text',
-            'id': 'a_date_field',
-            'name': 'a_date_field',
-            'placeholder': 'YYYY-MM-DD',
-            'value': '2019-01-12',
-            'data-format': 'yy-mm-dd',
+            'id': 'a_date_field_display',
+            'name': 'a_date_field_display',
             'class': 'form-control js_datepicker ',
             'required': '1',
         }
         self._test_widget_attributes(self.widget, 'input', expected_attrs)
+
+    def test_widget_date_input_custom_dp_attrs(self):
+        widget = self.get_widget(
+            self.w_name, self.w_field,
+            form=self.form, widget_model='cms.form.widget.date',
+            format='%m.%Y', placeholder='Custom',
+        )
+        self.assertEqual(widget.w_placeholder, 'Custom')
+        self.assertEqual(
+            widget.w_data_json(),
+            '{"defaultToday": true, "dp": {"format": "%m.%Y"}}'
+        )
 
     def test_widget_date_input_all_elems(self):
         node = self.to_xml_node(self.widget.render())[0]
         self._test_element_attributes(
             node, 'div', {'class': 'input-group'},
         )
-        self.assertEqual(len(node.getchildren()), 2)
+        self.assertEqual(len(node.getchildren()), 3)
         self._test_element_attributes(
             node.getchildren()[0], 'input', {}
         )
         self._test_element_attributes(
-            node.getchildren()[1], 'span',
+            node.getchildren()[1], 'input',
+            {'type': 'hidden'}
+        )
+        self._test_element_attributes(
+            node.getchildren()[2], 'span',
             {'class': 'input-group-addon js_datepicker_trigger'}
         )
         self._test_element_attributes(
-            node.getchildren()[1].getchildren()[0], 'span',
+            node.getchildren()[2].getchildren()[0], 'span',
             {'class': 'fa fa-calendar'}
         )
 
-    def test_widget_date_input_extract(self):
+    def test_widget_date_input_extract_default_format(self):
         self.assertEqual(self.widget.w_extract(a_date_field=''), None)
         self.assertEqual(
-            self.widget.w_extract(a_date_field='2019-01-12'), '2019-01-12')
+            self.widget.w_extract(a_date_field='2019-01-12'),
+            '2019-01-12'
+        )


### PR DESCRIPTION
* use bootstrap-datetimepicker which will allow to reuse
most of the same code for a datetime widget in the future.

* default to current language (date format and calendar translations)

* allow override of date format and placeholder via widget kwargs