### PR TITLE
[ADD] PoC for using pyval in cms_form

### DIFF
--- a/cms_form/README.rst
+++ b/cms_form/README.rst
@@ -68,6 +68,7 @@ Contributors
 ------------
 
 * Simone Orsi <simone.orsi@camptocamp.com>
+* Holger Brunn <hbrunn@therp.nl>
 
 Maintainer
 ----------

--- a/cms_form/doc/source/advanced.rst
+++ b/cms_form/doc/source/advanced.rst
@@ -17,17 +17,18 @@ For the simplest cases you don't have to write a single line of JS. You can do i
         _form_model_fields = ('name', 'type', 'foo')
 
         def _form_master_slave_info(self):
-            info = self._super._form_master_slave_info()
+            info = super()._form_master_slave_info()
             info.update({
                 # master field
                 'type':{
                     # actions
                     'hide': {
-                        # slave field: action values
+                        # slave field: list values of master field to trigger action
                         'foo': ('contact', ),
                     },
                     'show': {
-                        'foo': ('address', 'invoice', ),
+                        # or write python code that will be evaluated by pyeval
+                        'foo': 'form.type in ["address", "invoice"]',
                     }
                 },
             })

--- a/cms_form/static/src/js/master_slave.js
+++ b/cms_form/static/src/js/master_slave.js
@@ -5,8 +5,7 @@ odoo.define('cms_form.master_slave', function (require) {
     TODO: explain behavior.
     */
 
-    // TODO: this does not work ATM :(
-    // var pyeval = require('web.pyeval');
+    var pyeval = require('web.pyeval');
     var sAnimation = require('website.content.snippets.animation');
 
     sAnimation.registry.CMSFormMasterSlave = sAnimation.Class.extend({
@@ -41,9 +40,7 @@ odoo.define('cms_form.master_slave', function (require) {
                   val = $input.is(':checked');
                 }
                 $.each(mapping, function(slave_fname, values){
-                  if (_.contains(values, val)) {
-                    handler(slave_fname);
-                  }
+                  self.eval_master_slave(val, values, handler, slave_fname);
                 });
               }).filter(
                 'select,[type=checkbox],[type=radio]:checked,[type=text]'
@@ -52,6 +49,25 @@ odoo.define('cms_form.master_slave', function (require) {
             }
           });
         });
+      },
+      eval_master_slave: function (master_value, values, handler, slave) {
+        if (typeof(values) === 'string') {
+          if (pyeval.py_eval(values, this.eval_master_slave_context())) {
+              handler(slave);
+          }
+        }
+        else if (_.contains(values, master_value)) {
+          handler(slave);
+        }
+      },
+      eval_master_slave_context: function () {
+        var values = this.$el.serializeArray();
+
+        return {
+            form: _.object(
+                _.pluck(values, 'name'), _.pluck(values, 'value')
+            ),
+        };
       },
       handle_hide: function(slave_fname){
         $('[name="' + slave_fname +'"]').closest('.form-group').hide();

--- a/cms_form/templates/assets.xml
+++ b/cms_form/templates/assets.xml
@@ -13,6 +13,8 @@ License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 		</xpath>
 
 		<xpath expr="//script[last()]" position="after">
+            <script type="text/javascript" src="/web/static/lib/py.js/lib/py.js"></script>
+            <script type="text/javascript" src="/web/static/src/js/core/pyeval.js"></script>
 			<script type="text/javascript" src="/cms_form/static/src/js/select2widgets.js"></script>
 			<script type="text/javascript" src="/cms_form/static/src/js/date_widget.js"></script>
 			<script type="text/javascript" src="/cms_form/static/src/js/textarea_widget.js"></script>

--- a/cms_form_example/models/partner.py
+++ b/cms_form_example/models/partner.py
@@ -69,3 +69,25 @@ if not testing:
         _name = 'cms.form.res.partner.fset.tabbed'
         _inherit = 'cms.form.res.partner.fset'
         _form_fieldsets_display = 'tabs'
+
+        def _form_master_slave_info(self):
+            info = super()._form_master_slave_info()
+            info.update({
+                'category_id': {
+                    'hide': {
+                        'country_id': 'form.category_id == "5"',
+                    },
+                    'show': {
+                        'country_id': 'form.category_id != "5"',
+                    },
+                },
+                'name': {
+                    'readonly': {
+                        'category_id': 'form.name == "YourCompany"',
+                    },
+                    'no_readonly': {
+                        'category_id': 'form.name == "YourCompany2"',
+                    },
+                },
+            })
+            return info


### PR DESCRIPTION
this is the promised PR about using python in master slave fields. It's the minimal change version, but I'm not really happy with it, because currently, we need to write the `not $condition` version in the inverse of the action.

Wouldn't it be simpler to only use `show`, `readonly` and `required`, evaluate everything on every form change, and set the fields accordingly?

Then I just yank the values from the form, should we do some postprocessing here? For example have a list of integers for 2many fields and similar. But then I fear we're not far from reinventing backend widgets, and if we actually want that, we need to do something entirely else.

CC @gfcapalbo 