### PR TITLE
[11.0][FIX] cms_form. Ajax requests should also allow public user.

### DIFF
--- a/cms_form/controllers/main.py
+++ b/cms_form/controllers/main.py
@@ -207,7 +207,7 @@ class CMSSearchFormController(http.Controller, SearchFormControllerMixin):
     @http.route([
         '/cms/ajax/search/<string:model>',
         '/cms/ajax/search/<string:model>/<int:model_id>',
-    ], type='http', auth='user', website=True)
+    ], type='http', auth='public', website=True)
     def ajax(self, model, model_id=None, **kw):
         """handle an ajax request"""
         return self.make_response_ajax(model, **kw)


### PR DESCRIPTION
Websites that showed a search form worked showed the initial, unfiltered list to public users, but any attempt at ajax enabled filtering would result in an empty list.

The https://<website>/cms/ajax/search/<model>?<query parameters> would redirect the user to login, als ajax controller did not supprt public users.