### PR TITLE
[14.0] cms_info: backports from v16

### DIFF
--- a/cms_info/models/cms_mixin.py
+++ b/cms_info/models/cms_mixin.py
@@ -35,18 +35,22 @@ class CMSInfoMixin(models.AbstractModel):
     url = fields.Char(
         string="URL",
         compute="_compute_cms_url",
+        compute_sudo=True,
     )
     cms_edit_url = fields.Char(
         string="CMS edit URL",
         compute="_compute_cms_url",
+        compute_sudo=True,
     )
     cms_delete_url = fields.Char(
         string="CMS delete URL",
         compute="_compute_cms_url",
+        compute_sudo=True,
     )
     cms_delete_confirm_url = fields.Char(
         string="CMS delete confirm URL",
         compute="_compute_cms_url",
+        compute_sudo=True,
     )
 
     def _compute_cms_url(self):

--- a/cms_info/models/cms_mixin.py
+++ b/cms_info/models/cms_mixin.py
@@ -52,11 +52,17 @@ class CMSInfoMixin(models.AbstractModel):
         compute="_compute_cms_url",
         compute_sudo=True,
     )
+    cms_copy_url = fields.Char(
+        string="CMS copy URL",
+        compute="_compute_cms_url",
+        compute_sudo=True,
+    )
 
     def _compute_cms_url(self):
         for rec in self:
             rec.url = rec._get_cms_url()
             rec.cms_edit_url = rec._get_cms_edit_url()
+            rec.cms_copy_url = rec._get_cms_copy_url()
             rec.update(rec._get_cms_delete_urls())
 
     def _get_cms_url(self):
@@ -68,6 +74,10 @@ class CMSInfoMixin(models.AbstractModel):
     def _get_cms_edit_url(self):
         base_edit_url = self.cms_edit_url_base
         return f"{base_edit_url}/{self.id}"
+
+    def _get_cms_copy_url(self):
+        base_url = self._cms_make_url("copy")
+        return f"{base_url}/{self.id}"
 
     def _get_cms_delete_urls(self):
         base_url = self.cms_delete_url_base

--- a/cms_info/tests/test_info_mixin.py
+++ b/cms_info/tests/test_info_mixin.py
@@ -40,6 +40,12 @@ class TestInfoMixin(SavepointCase):
     def test_search_url(self):
         self.assertEqual(self.record.cms_search_url, "/cms/search/fake.model")
 
+    def test_view_url(self):
+        self.assertEqual(
+            self.record.url,
+            "/cms/view/fake.model/%s" % self.record.id,
+        )
+
     def test_edit_url(self):
         self.assertEqual(
             self.record.cms_edit_url,


### PR DESCRIPTION
* add a generic `url` field
* add specific hooks for each url type and simplify compute